### PR TITLE
나의 대여 목록 종료 시 showList 모드 변경, 검색 기능에 공백 제거 방식 수정, 싱글톤 객체 getter사용

### DIFF
--- a/app/src/main/java/com/example/jup_jup_android/entity/singleton/ItemStatusListManager.kt
+++ b/app/src/main/java/com/example/jup_jup_android/entity/singleton/ItemStatusListManager.kt
@@ -18,7 +18,7 @@ object ItemStatusListManager {
 
     private var originalDividedItemStatusList = ArrayList<ArrayList<ItemStatus>>()
 
-    var dividedShowItemStatusList = ArrayList<ArrayList<ItemStatus>>()
+    private var dividedShowItemStatusList = ArrayList<ArrayList<ItemStatus>>()
 
 
     fun initItemStatusList(context: Context, cnt: Int){
@@ -85,7 +85,8 @@ object ItemStatusListManager {
 
             for (i in 0 until itemStatusList.size) {
 
-                if (itemStatusList[i].name.toLowerCase(Locale.getDefault()).trim().contains(key) || itemStatusList[i].category.toLowerCase(Locale.getDefault()).trim().contains(key))
+                if (itemStatusList[i].name.toLowerCase(Locale.getDefault()).replace(" ", "").contains(key)
+                        || itemStatusList[i].category.toLowerCase(Locale.getDefault()).replace(" ", "").contains(key))
                 {
                     if (cnt == 5) {
                         dividedShowItemStatusList.add(ArrayList())

--- a/app/src/main/java/com/example/jup_jup_android/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/jup_jup_android/ui/activity/MainActivity.kt
@@ -13,16 +13,10 @@ import com.example.jup_jup_android.R
 import com.example.jup_jup_android.entity.singleton.ItemStatusListManager
 import com.example.jup_jup_android.ui.util.SetItemStatusList_PageView
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.*
 
 
 class MainActivity : AppCompatActivity() {
-
-    private val NEXT_PAGE = +1
-    private val PREV_PAGE = -1
-    private val THIS_PAGE = 0
-    var lastPage = 0
-    private lateinit var textViewArrayList: ArrayList<TextView>
-    private lateinit var viewPager : ViewPager
 
     private lateinit var pageView: SetItemStatusList_PageView
 
@@ -56,7 +50,7 @@ class MainActivity : AppCompatActivity() {
             editText_SearchText_MainActivitySearchMode.setText("")
             ItemStatusListManager.processShowList("")
             pageView.notifyDataSetChanged()
-            Log.d("TestLog", "showList = ${ItemStatusListManager.dividedShowItemStatusList}")
+            Log.d("TestLog", "showList = ${ItemStatusListManager.getShowList()}")
             Log.d("TestLog", "originalList = ${ItemStatusListManager.getOriginalDividedItemStatusList()}")
         }
 
@@ -68,7 +62,7 @@ class MainActivity : AppCompatActivity() {
         editText_SearchText_MainActivitySearchMode.addTextChangedListener {
             Log.d("TestLog", "${it}")
 
-            ItemStatusListManager.processShowList(it.toString().toLowerCase().trim())
+            ItemStatusListManager.processShowList(it.toString().toLowerCase(Locale.getDefault()).replace(" ", ""))
             pageView.syncPage()
             pageView.notifyDataSetChanged()
 

--- a/app/src/main/java/com/example/jup_jup_android/ui/activity/MyRentalListActivity.kt
+++ b/app/src/main/java/com/example/jup_jup_android/ui/activity/MyRentalListActivity.kt
@@ -26,7 +26,7 @@ class MyRentalListActivity : AppCompatActivity() {
     private fun setTitleBarItemsOnclick() {
 
         imageView_BackArrow_MyRentalListActivity.setOnClickListener {
-            finish()
+            back()
         }
 
         textView_ShowMode_MyRentalListActivity.setOnClickListener {
@@ -62,7 +62,13 @@ class MyRentalListActivity : AppCompatActivity() {
         textView_ShowMode_MyRentalListActivity.text = text
     }
 
-    override fun onBackPressed() {
+    private fun back(){
+        RentStatusListManager.showOriginalDividedList()
+        pageView.syncPage()
+        finish()
+    }
 
+    override fun onBackPressed() {
+        back()
     }
 }

--- a/app/src/main/java/com/example/jup_jup_android/ui/adapter/ItemStatusList_ViewPagerAdapter.kt
+++ b/app/src/main/java/com/example/jup_jup_android/ui/adapter/ItemStatusList_ViewPagerAdapter.kt
@@ -23,7 +23,7 @@ class ItemStatusList_ViewPagerAdapter(var context: Context) : PagerAdapter() {
     }
 
     override fun getCount(): Int {
-        return ItemStatusListManager.dividedShowItemStatusList.size
+        return ItemStatusListManager.getShowList().size
     }
 
     override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
@@ -36,7 +36,7 @@ class ItemStatusList_ViewPagerAdapter(var context: Context) : PagerAdapter() {
         val view: View = layoutInflater.inflate(R.layout.fragment_item_status_list, null)
 
         //메인 화면 (기자재 목록)
-        var adapter = ItemStatusList_RecyclerViewAdpater(ItemStatusListManager.dividedShowItemStatusList[position])
+        var adapter = ItemStatusList_RecyclerViewAdpater(ItemStatusListManager.getShowList()[position])
         view.recyclerView_ItemStatusList.adapter = adapter
         adapter.notifyDataSetChanged()
 
@@ -44,8 +44,5 @@ class ItemStatusList_ViewPagerAdapter(var context: Context) : PagerAdapter() {
 
         return view
     }
-
-
-
 
 }

--- a/app/src/main/java/com/example/jup_jup_android/ui/util/SetItemStatusList_PageView.kt
+++ b/app/src/main/java/com/example/jup_jup_android/ui/util/SetItemStatusList_PageView.kt
@@ -144,7 +144,7 @@ class SetItemStatusList_PageView(var context: Context, var view: View, var  data
         notifyDataSetChanged()
 
         lastPage = viewPager.currentItem
-        var size = ItemStatusListManager.dividedShowItemStatusList.size
+        var size = ItemStatusListManager.getShowList().size
         if(textViewArrayList[0].text.toString().toInt() > size){
             setPageNumsText(size - size%5 + 1)
         }


### PR DESCRIPTION
## 나의 대여 목록 종료 시 showList 모드 변경
나의 대여 목록에서 뒤로가기 버튼을 누르면 RentStatusListManager.showOriginalDividedList()를 실행해서 전체 보기 모드로 변경
(전체 보기 외의 모드에서 나의 대여 목록 페이지를 나갔다가 다시 들어오면 textView는 전체 인데 list의 아이템이 다른 오류 수정)


## 검색 기능에 공백 제거 방식 수정
trim() 메서드는 문자열의 모든 공백을 제거하는게 아니라 앞 뒤 공백만 제거해줌.
모든 공백을 제거해주는 replace(" ", "")로 변경


## 싱글톤 객체 getter 사용
itemStatusListManager.dividedShowItemStatusList -> itemStatusListManager.getShowList() 